### PR TITLE
FIX: Samsung devices on Lollipop will accrete alarms eventually leadi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.idea/.name
+.idea/cordova-plugin-local-notifications.iml
+.idea/misc.xml
+.idea/modules.xml
+.idea/vcs.xml
+.idea/workspace.xml

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="de.appplant.cordova.plugin.local-notification"
-        version="0.8.2dev">
+        version="0.8.2_dev">
 
     <name>LocalNotification</name>
 

--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -162,7 +162,7 @@ public class Builder {
                 .putExtra(Options.EXTRA, options.toString());
 
         PendingIntent dpi = PendingIntent.getBroadcast(
-                context, 0, deleteIntent, PendingIntent.FLAG_CANCEL_CURRENT);
+                context, 0, deleteIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
         builder.setDeleteIntent(dpi);
     }
@@ -186,7 +186,7 @@ public class Builder {
         int requestCode = new Random().nextInt();
 
         PendingIntent contentIntent = PendingIntent.getActivity(
-                context, requestCode, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+                context, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
         builder.setContentIntent(contentIntent);
     }

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -172,7 +172,7 @@ public class Notification {
                 .putExtra(Options.EXTRA, options.toString());
 
         PendingIntent pi = PendingIntent.getBroadcast(
-                context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+                context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
         if (isRepeating()) {
             getAlarmMgr().setRepeating(AlarmManager.RTC_WAKEUP,


### PR DESCRIPTION
…ng to app crash when attempting to schedule new local notifications. Once in this state, the app will continue to crash until the device is power cycled or the app is reinstalled. Per Stack Overflow http://stackoverflow.com/a/29703161 the fault lies in the use of PendingIntent.FLAG_CANCEL_CURRENT.

To see what's happening, connect to a device with adb and run adb shell dumpsys alarm | grep -c "youApp'sWidgetIDFromConfig.xml". Then schedule reminders, recheck the alarm count. Continue to schedule reminders, when the count reaches 1000 the app will crash.

Post fix, the alarm count does not continue to increase.
